### PR TITLE
Fix bug where active element is not always focused

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,9 +22,7 @@ export default React.createClass({
   },
 
   componentDidUpdate (prevProps) {
-    if (prevProps.activeElement !== this.props.activeElement) {
-      this.focusChild(this.props.activeElement)
-    }
+    this.focusChild(this.props.activeElement)
   },
 
   componentDidMount () {


### PR DESCRIPTION
Previously, `.focus()` was called on the active element only when the previous
`activeElement` prop was equal to the current prop. This prevented the active
element from focusing if the active element had been unfocused by some user
action, and then another action triggers the same element to be focused again.

For example, a text input that focused another input after its value reached a
certain length would not work if the user returned to the first input after the
focus had already been changed, because the `activeElement` prop is the same
between component updates.
